### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/models.py
+++ b/models.py
@@ -52,7 +52,7 @@ class Entry(db.Model):
         return db.session.commit()
 
     def __repr__(self):
-        return '<Entry %r>' % self.slug
+        return '<Entry {0!r}>'.format(self.slug)
 
 
 class Tags(db.Model):
@@ -74,4 +74,4 @@ class Tags(db.Model):
         return db.session.commit()
 
     def __repr__(self):
-        return '<Tag %r>' % self.name
+        return '<Tag {0!r}>'.format(self.name)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:VolVoz:personal-blog?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:VolVoz:personal-blog?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
